### PR TITLE
Archive provider

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,9 @@ group :development, :test do
   gem 'puppet-blacksmith', '~> 3.3.1'
   gem 'puppet-lint', '~> 1.1.0'
   gem 'puppet-syntax', '~> 2.1.0'
+  # try to be compatible with ruby 1.9.3
+  gem 'json_pure', '< 2.0.0'
+  gem 'rest-client', '~> 1.8.0'
 end
 
 group :system_tests do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -213,7 +213,7 @@ GEM
       json_pure
     puppet-blacksmith (3.3.1)
       puppet (>= 2.7.16)
-      rest-client
+      rest-client (~> 1.8.0)
     puppet-lint (1.1.0)
     puppet-syntax (2.1.0)
       rake
@@ -285,7 +285,7 @@ PLATFORMS
 DEPENDENCIES
   beaker (~> 2.37.0)
   beaker-rspec (~> 5.3.0)
-  puppet (~> 4.4.0)
+  puppet (>= 2.7.0, < 5.0)
   puppet-blacksmith (~> 3.3.1)
   puppet-lint (~> 1.1.0)
   puppet-syntax (~> 2.1.0)

--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ class { 'roundcube':
 ```
 (see below for more information)
 
+##Archive Module
+This module supports both well-known `archive` modules. This allows you to use your favorite archive module (either https://github.com/voxpupuli/puppet-archive or https://github.com/camptocamp/puppet-archive). Please make sure that the required archive module is installed and that you have set the parameter `archive_provider` to either `camptocamp` (default) or `puppet`.
+
+
 ##Advanced usage
 
 Specify advanced parameters

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -39,6 +39,15 @@
 # [*document_root_manage*]
 #   Whether to manage the `document_root` file resource or not: either `true` or `false`.
 #
+# [*archive_provider*]
+#   Select which `archive` type should be used to download RoundCube from the
+#   download site. There exist at least two modules that provide an `archive`
+#   type: "camptocamp/archive" and "nanliu/archive" (or "puppet/archive"
+#   since the module is now in the care of puppet-community). Defaults to
+#   'camptocamp'. If you set this to 'nanliu' (or 'puppet') make sure you have
+#   that module installed since both cannot be recorded as a dependency in
+#   metadata.json at the same time.
+#
 # [*db_dsn*]
 #   Set the database data source name (DSN) to be used when connecting to the database. Setting this parameter will
 #   override the other `db_*` parameters. See http://pear.php.net/manual/en/package.database.mdb2.intro-dsn.php for
@@ -108,6 +117,8 @@ class roundcube (
   $document_root                   = $roundcube::params::document_root,
   $document_root_manage            = $roundcube::params::document_root_manage,
 
+  $archive_provider                = roundcube::params::archive_provider,
+
   $db_dsn                          = undef,
   $db_type                         = 'pgsql',
   $db_name                         = 'roundcubemail',
@@ -133,6 +144,7 @@ class roundcube (
   validate_bool($composer_disable_git_ssl_verify)
   validate_absolute_path($document_root)
   validate_bool($document_root_manage)
+  validate_string($archive_provider)
   validate_string($db_type)
   validate_string($db_name)
   validate_string($db_host)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -117,7 +117,7 @@ class roundcube (
   $document_root                   = $roundcube::params::document_root,
   $document_root_manage            = $roundcube::params::document_root_manage,
 
-  $archive_provider                = roundcube::params::archive_provider,
+  $archive_provider                = $roundcube::params::archive_provider,
 
   $db_dsn                          = undef,
   $db_type                         = 'pgsql',

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -18,16 +18,16 @@ class roundcube::install inherits roundcube {
   case $roundcube::archive_provider {
     'nanliu', 'puppet': {
       archive { "${roundcube::package_dir}/${archive}.tar.gz":
-        ensure           => present,
-        checksum         => $roundcube::checksum,
-        checksum_type    => $roundcube::checksum_type,
-        source           => $download_url,
-        extract_path     => $roundcube::install_dir,
-        creates          => "${roundcube::package_dir}/${archive}.tar.gz",
-        extract          => true,
-        cleanup          => false,
-        extract_flags    => '-x --no-same-owner -f',
-        require          => [
+        ensure        => present,
+        checksum      => $roundcube::checksum,
+        checksum_type => $roundcube::checksum_type,
+        source        => $download_url,
+        extract_path  => $roundcube::install_dir,
+        creates       => "${roundcube::package_dir}/${archive}.tar.gz",
+        extract       => true,
+        cleanup       => false,
+        extract_flags => '-x --no-same-owner -f',
+        require       => [
           File[$roundcube::install_dir],
           File[$roundcube::package_dir]
         ],

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -11,6 +11,7 @@ class roundcube::params {
   $checksum = '476a1d45b0592b2ad43e3e08cbc72e69ef31e33ed8a8f071f02e5a1ae3e7f334'
   $checksum_type = 'sha256'
 
+  $archive_provider = 'camptocamp'
   $package_dir = '/var/cache/puppet/archives'
   $install_dir = '/opt'
 

--- a/metadata.json
+++ b/metadata.json
@@ -35,10 +35,6 @@
   ],
   "dependencies": [
     {
-      "name": "camptocamp/archive",
-      "version_requirement": "0.x"
-    },
-    {
       "name": "willdurand/composer",
       "version_requirement": "1.x"
     },

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,16 +1,17 @@
 require 'spec_helper'
 
-describe 'roundcube' do
+describe 'roundcube', :type => :class do
   let(:title) { 'roundcube' }
   let(:facts) { {:concat_basedir => '/path/to/dir'} }
   let(:current_version) { '1.1.5' }
+  let(:archive_provider) { 'camptocamp' }
   let(:archive_name) { "roundcubemail-#{current_version}-complete" }
   let(:install_dir) { "/opt/roundcubemail-#{current_version}" }
   let(:config_file) { "#{install_dir}/config/config.inc.php" }
   let(:config_file_options_fragment) { "#{config_file}__options" }
 
   describe 'by default' do
-    let(:params) { {} }
+    let(:params) { {:archive_provider => archive_provider} }
 
     specify { should contain_archive(archive_name) }
     specify { should contain_file('/var/www/roundcubemail').with(
@@ -21,37 +22,37 @@ describe 'roundcube' do
   end
 
   describe 'installs custom version' do
-    let(:params) { {:version => '1.2.3'} }
+    let(:params) { {:archive_provider => archive_provider, :version => '1.2.3'} }
 
     specify { should contain_archive('roundcubemail-1.2.3-complete') }
   end
 
   describe 'uses custom archive checksum' do
-    let(:params) { {:checksum => '123'} }
+    let(:params) { {:archive_provider => archive_provider, :checksum => '123'} }
 
     specify { should contain_archive(archive_name).with_digest_string('123') }
   end
 
   describe 'uses custom archive checksum type' do
-    let(:params) { {:checksum_type => 'sha1'} }
+    let(:params) { {:archive_provider => archive_provider, :checksum_type => 'sha1'} }
 
     specify { should contain_archive(archive_name).with_digest_type('sha1') }
   end
 
   describe 'stores packages in custom directory' do
-    let(:params) { {:package_dir => '/somewhere/else'} }
+    let(:params) { {:archive_provider => archive_provider, :package_dir => '/somewhere/else'} }
 
     specify { should contain_archive(archive_name).with_src_target('/somewhere/else') }
   end
 
   describe 'installs application in custom directory' do
-    let(:params) { {:install_dir => '/somewhere/else'} }
+    let(:params) { {:archive_provider => archive_provider, :install_dir => '/somewhere/else'} }
 
     specify { should contain_archive(archive_name).with_target('/somewhere/else') }
   end
 
   describe 'should create symbolic link to specified document_root' do
-    let(:params) { {:document_root => '/path/to/document_root'} }
+    let(:params) { {:archive_provider => archive_provider, :document_root => '/path/to/document_root'} }
 
     specify { should contain_file('/path/to/document_root').with(
         'ensure' => 'link',
@@ -61,13 +62,13 @@ describe 'roundcube' do
   end
 
   describe 'should not manage document_root if configured' do
-    let(:params) { {:document_root_manage => false} }
+    let(:params) { {:archive_provider => archive_provider, :document_root_manage => false} }
 
     specify { should_not contain_file('/var/www/roundcubemail') }
   end
 
   describe 'should not accept document_root as a boolean string' do
-    let(:params) { {:document_root_manage => 'false'} }
+    let(:params) { {:archive_provider => archive_provider, :document_root_manage => 'false'} }
 
     specify do
       expect { should contain_archive(archive_name) }.to raise_error(Puppet::Error, /is not a boolean/)
@@ -75,7 +76,7 @@ describe 'roundcube' do
   end
 
   describe 'should not accept invalid document_root_ensure' do
-    let(:params) { {:document_root_manage => 'invalid'} }
+    let(:params) { {:archive_provider => archive_provider, :document_root_manage => 'invalid'} }
 
     specify do
       expect { should contain_archive(archive_name) }.to raise_error(Puppet::Error, /invalid/)
@@ -83,44 +84,44 @@ describe 'roundcube' do
   end
 
   describe 'creates database configuration file with proper database url' do
-    let(:params) { {:db_host => 'example.com', :db_name => 'name', :db_username => 'user', :db_password => 'foo<bar'} }
+    let(:params) { {:archive_provider => archive_provider, :db_host => 'example.com', :db_name => 'name', :db_username => 'user', :db_password => 'foo<bar'} }
 
     specify { should contain_concat__fragment(config_file_options_fragment).with_content(/^\$config\['db_dsnw'\] = 'pgsql:\/\/user:foo%3Cbar@example.com\/name';$/) }
   end
 
   describe 'creates configuration file with proper imap host' do
-    let(:params) { {:imap_host => 'ssl://localhost'} }
+    let(:params) { {:archive_provider => archive_provider, :imap_host => 'ssl://localhost'} }
 
     specify { should contain_concat__fragment(config_file_options_fragment).with_content(/^\$config\['default_host'\] = 'ssl:\/\/localhost';$/) }
   end
 
   describe 'creates configuration file with proper imap port' do
-    let(:params) { {:imap_port => 993} }
+    let(:params) { {:archive_provider => archive_provider, :imap_port => 993} }
 
     specify { should contain_concat__fragment(config_file_options_fragment).with_content(/^\$config\['default_port'\] = [']?993[']?;$/) }
   end
 
   describe 'creates configuration file with salt' do
-    let(:params) { {:des_key => 'some-salt'} }
+    let(:params) { {:archive_provider => archive_provider, :des_key => 'some-salt'} }
 
     specify { should contain_concat__fragment(config_file_options_fragment).with_content(/^\$config\['des_key'\] = 'some-salt';$/) }
   end
 
   describe 'creates configuration file with enabled plugins' do
-    let(:params) { {:plugins => ['plugin1', 'plugin2']} }
+    let(:params) { {:archive_provider => archive_provider, :plugins => ['plugin1', 'plugin2']} }
 
     specify { should contain_roundcube__plugin('plugin1') }
     specify { should contain_roundcube__plugin('plugin2') }
   end
 
   describe 'create configuration file with custom language' do
-    let(:params) { {:options_hash => {'language' => 'en_US'}} }
+    let(:params) { {:archive_provider => archive_provider, :options_hash => {'language' => 'en_US'}} }
 
     specify { should contain_concat__fragment(config_file_options_fragment).with_content(/^\$config\['language'\] = 'en_US';$/) }
   end
 
   describe 'ensures the logs directory is writable by the webserver' do
-    let(:params) { {:version => '1.0.0', :process => 'webserver'} }
+    let(:params) { {:archive_provider => archive_provider, :version => '1.0.0', :process => 'webserver'} }
 
     specify { should contain_file('/opt/roundcubemail-1.0.0/logs').with({
         'ensure' => 'directory',
@@ -132,7 +133,7 @@ describe 'roundcube' do
   end
 
   describe 'ensures the temp directory is writable by the webserver' do
-    let(:params) { {:version => '1.0.0', :process => 'webserver'} }
+    let(:params) { {:archive_provider => archive_provider, :version => '1.0.0', :process => 'webserver'} }
 
     specify { should contain_file('/opt/roundcubemail-1.0.0/temp').with({
         'ensure' => 'directory',

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -4,15 +4,12 @@ describe 'roundcube', :type => :class do
   let(:title) { 'roundcube' }
   let(:facts) { {:concat_basedir => '/path/to/dir'} }
   let(:current_version) { '1.1.5' }
-  let(:archive_provider) { 'camptocamp' }
   let(:archive_name) { "roundcubemail-#{current_version}-complete" }
   let(:install_dir) { "/opt/roundcubemail-#{current_version}" }
   let(:config_file) { "#{install_dir}/config/config.inc.php" }
   let(:config_file_options_fragment) { "#{config_file}__options" }
 
   describe 'by default' do
-    let(:params) { {:archive_provider => archive_provider} }
-
     specify { should contain_archive(archive_name) }
     specify { should contain_file('/var/www/roundcubemail').with(
         'ensure' => 'link',
@@ -22,37 +19,37 @@ describe 'roundcube', :type => :class do
   end
 
   describe 'installs custom version' do
-    let(:params) { {:archive_provider => archive_provider, :version => '1.2.3'} }
+    let(:params) { {:version => '1.2.3'} }
 
     specify { should contain_archive('roundcubemail-1.2.3-complete') }
   end
 
   describe 'uses custom archive checksum' do
-    let(:params) { {:archive_provider => archive_provider, :checksum => '123'} }
+    let(:params) { {:checksum => '123'} }
 
     specify { should contain_archive(archive_name).with_digest_string('123') }
   end
 
   describe 'uses custom archive checksum type' do
-    let(:params) { {:archive_provider => archive_provider, :checksum_type => 'sha1'} }
+    let(:params) { {:checksum_type => 'sha1'} }
 
     specify { should contain_archive(archive_name).with_digest_type('sha1') }
   end
 
   describe 'stores packages in custom directory' do
-    let(:params) { {:archive_provider => archive_provider, :package_dir => '/somewhere/else'} }
+    let(:params) { {:package_dir => '/somewhere/else'} }
 
     specify { should contain_archive(archive_name).with_src_target('/somewhere/else') }
   end
 
   describe 'installs application in custom directory' do
-    let(:params) { {:archive_provider => archive_provider, :install_dir => '/somewhere/else'} }
+    let(:params) { {:install_dir => '/somewhere/else'} }
 
     specify { should contain_archive(archive_name).with_target('/somewhere/else') }
   end
 
   describe 'should create symbolic link to specified document_root' do
-    let(:params) { {:archive_provider => archive_provider, :document_root => '/path/to/document_root'} }
+    let(:params) { {:document_root => '/path/to/document_root'} }
 
     specify { should contain_file('/path/to/document_root').with(
         'ensure' => 'link',
@@ -62,13 +59,13 @@ describe 'roundcube', :type => :class do
   end
 
   describe 'should not manage document_root if configured' do
-    let(:params) { {:archive_provider => archive_provider, :document_root_manage => false} }
+    let(:params) { {:document_root_manage => false} }
 
     specify { should_not contain_file('/var/www/roundcubemail') }
   end
 
   describe 'should not accept document_root as a boolean string' do
-    let(:params) { {:archive_provider => archive_provider, :document_root_manage => 'false'} }
+    let(:params) { {:document_root_manage => 'false'} }
 
     specify do
       expect { should contain_archive(archive_name) }.to raise_error(Puppet::Error, /is not a boolean/)
@@ -76,7 +73,7 @@ describe 'roundcube', :type => :class do
   end
 
   describe 'should not accept invalid document_root_ensure' do
-    let(:params) { {:archive_provider => archive_provider, :document_root_manage => 'invalid'} }
+    let(:params) { {:document_root_manage => 'invalid'} }
 
     specify do
       expect { should contain_archive(archive_name) }.to raise_error(Puppet::Error, /invalid/)
@@ -84,44 +81,44 @@ describe 'roundcube', :type => :class do
   end
 
   describe 'creates database configuration file with proper database url' do
-    let(:params) { {:archive_provider => archive_provider, :db_host => 'example.com', :db_name => 'name', :db_username => 'user', :db_password => 'foo<bar'} }
+    let(:params) { {:db_host => 'example.com', :db_name => 'name', :db_username => 'user', :db_password => 'foo<bar'} }
 
     specify { should contain_concat__fragment(config_file_options_fragment).with_content(/^\$config\['db_dsnw'\] = 'pgsql:\/\/user:foo%3Cbar@example.com\/name';$/) }
   end
 
   describe 'creates configuration file with proper imap host' do
-    let(:params) { {:archive_provider => archive_provider, :imap_host => 'ssl://localhost'} }
+    let(:params) { {:imap_host => 'ssl://localhost'} }
 
     specify { should contain_concat__fragment(config_file_options_fragment).with_content(/^\$config\['default_host'\] = 'ssl:\/\/localhost';$/) }
   end
 
   describe 'creates configuration file with proper imap port' do
-    let(:params) { {:archive_provider => archive_provider, :imap_port => 993} }
+    let(:params) { {:imap_port => 993} }
 
     specify { should contain_concat__fragment(config_file_options_fragment).with_content(/^\$config\['default_port'\] = [']?993[']?;$/) }
   end
 
   describe 'creates configuration file with salt' do
-    let(:params) { {:archive_provider => archive_provider, :des_key => 'some-salt'} }
+    let(:params) { {:des_key => 'some-salt'} }
 
     specify { should contain_concat__fragment(config_file_options_fragment).with_content(/^\$config\['des_key'\] = 'some-salt';$/) }
   end
 
   describe 'creates configuration file with enabled plugins' do
-    let(:params) { {:archive_provider => archive_provider, :plugins => ['plugin1', 'plugin2']} }
+    let(:params) { {:plugins => ['plugin1', 'plugin2']} }
 
     specify { should contain_roundcube__plugin('plugin1') }
     specify { should contain_roundcube__plugin('plugin2') }
   end
 
   describe 'create configuration file with custom language' do
-    let(:params) { {:archive_provider => archive_provider, :options_hash => {'language' => 'en_US'}} }
+    let(:params) { {:options_hash => {'language' => 'en_US'}} }
 
     specify { should contain_concat__fragment(config_file_options_fragment).with_content(/^\$config\['language'\] = 'en_US';$/) }
   end
 
   describe 'ensures the logs directory is writable by the webserver' do
-    let(:params) { {:archive_provider => archive_provider, :version => '1.0.0', :process => 'webserver'} }
+    let(:params) { {:version => '1.0.0', :process => 'webserver'} }
 
     specify { should contain_file('/opt/roundcubemail-1.0.0/logs').with({
         'ensure' => 'directory',
@@ -133,7 +130,7 @@ describe 'roundcube', :type => :class do
   end
 
   describe 'ensures the temp directory is writable by the webserver' do
-    let(:params) { {:archive_provider => archive_provider, :version => '1.0.0', :process => 'webserver'} }
+    let(:params) { {:version => '1.0.0', :process => 'webserver'} }
 
     specify { should contain_file('/opt/roundcubemail-1.0.0/temp').with({
         'ensure' => 'directory',

--- a/spec/defines/plugin_spec.rb
+++ b/spec/defines/plugin_spec.rb
@@ -10,12 +10,24 @@ describe 'roundcube::plugin' do
   describe 'by default' do
     let(:params) { {} }
 
+    let :pre_condition do
+      'class {"roundcube":
+         archive_provider => "camptocamp",
+       }'
+    end
+
     specify { should contain_concat(config_file) }
     specify { should contain_concat__fragment("#{config_file}__default_config").with_source("#{install_dir}/plugins/password/config.inc.php.dist") }
   end
 
   describe 'with custom configuration' do
     let(:params) { {:options_hash => {'password_db_dsn' => 'psql://somewhere/else'}} }
+
+    let :pre_condition do
+      'class {"roundcube":
+         archive_provider => "camptocamp",
+       }'
+    end
 
     specify { should contain_concat__fragment("#{config_file}__custom_config").with_content(/^\$config\['password_db_dsn'\] = 'psql:\/\/somewhere\/else';$/) }
   end

--- a/spec/defines/plugin_spec.rb
+++ b/spec/defines/plugin_spec.rb
@@ -10,24 +10,12 @@ describe 'roundcube::plugin' do
   describe 'by default' do
     let(:params) { {} }
 
-    let :pre_condition do
-      'class {"roundcube":
-         archive_provider => "camptocamp",
-       }'
-    end
-
     specify { should contain_concat(config_file) }
     specify { should contain_concat__fragment("#{config_file}__default_config").with_source("#{install_dir}/plugins/password/config.inc.php.dist") }
   end
 
   describe 'with custom configuration' do
     let(:params) { {:options_hash => {'password_db_dsn' => 'psql://somewhere/else'}} }
-
-    let :pre_condition do
-      'class {"roundcube":
-         archive_provider => "camptocamp",
-       }'
-    end
 
     specify { should contain_concat__fragment("#{config_file}__custom_config").with_content(/^\$config\['password_db_dsn'\] = 'psql:\/\/somewhere\/else';$/) }
   end


### PR DESCRIPTION
This patch adds support for both well-known `archive` providers. This allows anyone to use their favorite archive module (either https://github.com/voxpupuli/puppet-archive or https://github.com/camptocamp/puppet-archive).