### PR TITLE
allow to make puppet composer module optional

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -117,6 +117,7 @@ class roundcube (
   $exec_paths                      = $roundcube::params::exec_paths,
   $composer_command_name           = $roundcube::params::composer_command_name,
   $composer_disable_git_ssl_verify = $roundcube::params::composer_disable_git_ssl_verify,
+  $composer_manage                 = $roundcube::params::composer_manage,
   $document_root                   = $roundcube::params::document_root,
   $document_root_manage            = $roundcube::params::document_root_manage,
 
@@ -146,6 +147,7 @@ class roundcube (
   validate_absolute_path($install_dir)
   validate_string($composer_command_name)
   validate_bool($composer_disable_git_ssl_verify)
+  validate_bool($composer_manage)
   validate_absolute_path($document_root)
   validate_bool($document_root_manage)
   validate_string($archive_provider)

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -8,7 +8,7 @@
 #
 class roundcube::install inherits roundcube {
 
-  if ($composer_manage == true) {
+  if ($roundcube::composer_manage == true) {
     include composer
   }
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -8,7 +8,9 @@
 #
 class roundcube::install inherits roundcube {
 
-  include composer
+  if ($composer_manage == true) {
+    include composer
+  }
 
   $archive = "roundcubemail-${roundcube::version}-complete"
   $target = "${roundcube::install_dir}/roundcubemail-${roundcube::version}"

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,4 +22,5 @@ class roundcube::params {
   $exec_paths = ['/usr/local/sbin', '/usr/local/bin', '/usr/sbin', '/usr/bin', '/sbin', '/bin']
   $composer_command_name = 'composer'
   $composer_disable_git_ssl_verify = false
+  $composer_manage = true
 }

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -26,10 +26,10 @@ define roundcube::plugin (
   $config_file_template = undef,
   $options_hash = {},
 ) {
+  include roundcube
   if ($roundcube::composer_manage == true) {
     include composer
   }
-  include roundcube
 
   $application_dir = $roundcube::install::target
   $config_file = $roundcube::config::config_file

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -26,7 +26,9 @@ define roundcube::plugin (
   $config_file_template = undef,
   $options_hash = {},
 ) {
-  include composer
+  if ($roundcube::composer_manage == true) {
+    include composer
+  }
   include roundcube
 
   $application_dir = $roundcube::install::target


### PR DESCRIPTION
`willdurand/composer` a hard requirement but it only provides the composer executeable. this file can be provided by other things like `puppet/php` or in my case by my `profile::php`.
to allow the user of this module to use it without requiring `willdurand/composer` it should be optional. which this PR is for.