### PR TITLE
add parameter $cronjobs_manage

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -72,15 +72,17 @@ class roundcube::config inherits roundcube {
 
   roundcube::plugin { $roundcube::plugins: }
 
-  file { '/etc/cron.daily/roundcube-cleandb':
-    ensure => absent,
-  }
+  if $roundcube::cronjobs_manage == true {
+    file { '/etc/cron.daily/roundcube-cleandb':
+      ensure => absent,
+    }
 
-  cron { 'roundcube-cleandb':
-    ensure  => present,
-    command => "${application_dir}/bin/cleandb.sh > /dev/null",
-    user    => 'root',
-    hour    => fqdn_rand(24),
-    minute  => fqdn_rand(60),
+    cron { 'roundcube-cleandb':
+      ensure  => present,
+      command => "${application_dir}/bin/cleandb.sh > /dev/null",
+      user    => 'root',
+      hour    => fqdn_rand(24),
+      minute  => fqdn_rand(60),
+    }
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -102,6 +102,9 @@
 #   Specify custom Roundcube configuration settings. See config/defaults.inc.php in the roundcube directory for a
 #   complete list of possible configuration arguments.
 #
+# [*cronjobs_manage*]
+#   Whether to manage cronjobs for Roundcube: either `true` or `false`.
+#
 # === Copyright
 #
 # Copyright 2015 Martin Meinhold, unless otherwise noted.
@@ -136,6 +139,7 @@ class roundcube (
   $des_key                         = 'rcmail-!24ByteDESkey*Str',
   $plugins                         = [],
   $plugins_manage                  = $roundcube::params::plugins_manage,
+  $cronjobs_manage                 = $roundcube::params::cronjobs_manage,
 
   $config_file_template            = undef,
   $options_hash                    = {},
@@ -161,6 +165,7 @@ class roundcube (
   validate_string($des_key)
   validate_array($plugins)
   validate_bool($plugins_manage)
+  validate_bool($cronjobs_manage)
   validate_hash($options_hash)
 
   if !empty($plugins) and $plugins_manage == false {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -25,4 +25,5 @@ class roundcube::params {
   $composer_manage = true
 
   $plugins_manage = true
+  $cronjobs_manage = true
 }


### PR DESCRIPTION
This PR adds the new parameter `$cronjobs_manage`. It controls wether the module manages cronjobs or not. It makes it possible to disable these cronjobs completely or to use custom cronjobs, that are managed by other modules/profiles (which is our use-case).

The default value is `true`, so this PR does not change anything for existing installations.