### PR TITLE
Make compatible with FreeBSD

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -84,7 +84,7 @@ class roundcube::install inherits roundcube {
     source  => "${target}/composer.json-dist",
     replace => false,
     owner   => 'root',
-    group   => 'root',
+    group   => 0,
     mode    => '0644',
     require => $require_archive,
   }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -16,7 +16,7 @@ class roundcube::service inherits roundcube {
       ensure => link,
       target => $roundcube::install::target,
       owner  => 'root',
-      group  => 'root',
+      group  => 0,
     }
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -25,6 +25,9 @@
         "14.04",
         "16.04"
       ]
+    },
+    {
+      "operatingsystem": "FreeBSD"
     }
   ],
   "requirements": [


### PR DESCRIPTION
On FreeBSD the group of user root is not "root", but "wheel" instead. By using the GID instead of the group name we can easily workaround this incompatibility between Linux and FreeBSD.
