### PR TITLE
Replace unencrypted git protocol when cloning fixtures

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -14,10 +14,10 @@ fixtures:
       ref: "v6.6.0"
     # provided by puppet-agent
     augeas:
-      repo: "git://github.com/puppetlabs/puppetlabs-augeas_core"
+      repo: "https://github.com/puppetlabs/puppetlabs-augeas_core"
       ref: "1.0.5"
     cron:
-      repo: "git://github.com/puppetlabs/puppetlabs-cron_core"
+      repo: "https://github.com/puppetlabs/puppetlabs-cron_core"
       ref: "1.0.4"
     # transitive dependencies
     wget:


### PR DESCRIPTION
See https://github.blog/2021-09-01-improving-git-protocol-security-github/